### PR TITLE
Added support for passing some common PhpUnit test execution options

### DIFF
--- a/src/Commands/DuskInteractiveCommand.php
+++ b/src/Commands/DuskInteractiveCommand.php
@@ -52,7 +52,7 @@ class DuskInteractiveCommand extends Command
             1 => 'Run Laravel Dusk Normally',
         ];
 
-        foreach(glob(base_path() . $this->directory .'*.php') as $filename) {
+        foreach (glob(base_path() . $this->directory . '*.php') as $filename) {
             // replace full path
             $f = str_replace(base_path() . $this->directory, '', $filename);
 
@@ -70,7 +70,7 @@ class DuskInteractiveCommand extends Command
         $key = array_search($choice, $files);
 
         // what kind of dusk test are we running
-        switch($key) {
+        switch ($key) {
             case 0:
                 // exit program
                 $this->info('Exiting program');
@@ -87,7 +87,7 @@ class DuskInteractiveCommand extends Command
                 break;
             default:
                 // single test
-                $this->info('Starting Laravel Dusk with the following test '. $files[$key]);
+                $this->info('Starting Laravel Dusk with the following test ' . $files[$key]);
 
                 // execute dusk with the specific test
                 exec('php artisan dusk '. substr($this->directory, 1) . $files[$key] .'.php', $output);
@@ -98,11 +98,15 @@ class DuskInteractiveCommand extends Command
         }
     }
 
+    /**
+     * Output the result.
+     *
+     * @param array $output
+     */
     public function output($output)
     {
-        foreach($output as $line) {
+        foreach ($output as $line) {
             $this->info($line);
         }
     }
-
 }

--- a/src/Commands/DuskInteractiveCommand.php
+++ b/src/Commands/DuskInteractiveCommand.php
@@ -11,7 +11,31 @@ class DuskInteractiveCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'dusk:interactive';
+    protected $signature = 'dusk:interactive
+                            {--stop-on-error       : Stop execution upon first error}
+                            {--stop-on-failure     : Stop execution upon first error or failure}
+                            {--stop-on-warning     : Stop execution upon first warning}
+                            {--stop-on-risky       : Stop execution upon first risky test}
+                            {--stop-on-skipped     : Stop execution upon first skipped test}
+                            {--stop-on-incomplete  : Stop execution upon first incomplete test}
+                            {--fail-on-warning     : Treat tests with warnings as failures}
+                            {--fail-on-risky       : Treat risky tests as failures}';
+
+    /**
+     * Native PHPUnit options that can be passed when running tests.
+     *
+     * @var array
+     */
+    protected $phpUnitOptions = [
+        'stop-on-error',
+        'stop-on-failure',
+        'stop-on-warning',
+        'stop-on-risky',
+        'stop-on-skipped',
+        'stop-on-incomplete',
+        'fail-on-warning',
+        'fail-on-risky',
+    ];
 
     /**
      * The console command description.
@@ -80,7 +104,7 @@ class DuskInteractiveCommand extends Command
                 $this->info('Starting Laravel Dusk normally');
 
                 // execute dusk
-                exec('php artisan dusk', $output);
+                exec("php artisan dusk {$this->setPhpUnitOptions()}", $output);
 
                 // output result
                 $this->output($output);
@@ -90,12 +114,31 @@ class DuskInteractiveCommand extends Command
                 $this->info('Starting Laravel Dusk with the following test ' . $files[$key]);
 
                 // execute dusk with the specific test
-                exec('php artisan dusk '. substr($this->directory, 1) . $files[$key] .'.php', $output);
+                $testName = substr($this->directory, 1) . $files[$key] . '.php';
+                exec("php artisan dusk {$testName} {$this->setPhpUnitOptions()}", $output);
 
                 // output result
                 $this->output($output);
                 break;
         }
+    }
+
+    /**
+     * Set the options to run the Dusk tests with.
+     *
+     * @return string
+     */
+    public function setPhpUnitOptions()
+    {
+        $options = '';
+
+        foreach ($this->phpUnitOptions as $phpUnitOption) {
+            if ($this->option($phpUnitOption)) {
+                $options .= "--{$phpUnitOption} ";
+            }
+        }
+
+        return $options;
     }
 
     /**

--- a/src/DuskInteractiveServiceProvider.php
+++ b/src/DuskInteractiveServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Laracademy\Commands;
 
 use Illuminate\Support\ServiceProvider;


### PR DESCRIPTION
If I'm running a large test suite on a volatile codebase, I like to use the `--stop-on-failure` flag in PhpUnit to save time. This allows me to quickly resolve any issues as soon as they're found, before resuming all my tests again.

As such, I've added some common PhpUnit test execution options to this command. This means you can enjoy the benefits of the interactive Dusk command, but still have control over the strictness of your tests.

I also tweaked a few lines of code for PSR-2 compliance as well.